### PR TITLE
Read 1 Line Only Fix?

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ echo "Conflicts: \c" >> $controlfile
 
 # parse conflicts
 
-while IFS='' read -r line || [[ -n "$line" ]]; do
+while IFS='' read -r line || [[ "$line" ]]; do
 	dt="$(echo "$line"|tr -d '\r\n')"
     echo "$dt\c" >> $controlfile 
 done < "$conflictfile"


### PR DESCRIPTION
remove -n parameter. possible fix to it only reading line 1 of conflicts.txt.  the -n parameter can be used to specify how many lines should be extracted